### PR TITLE
kr => kr.

### DIFF
--- a/polyfill.number.toLocaleString.js
+++ b/polyfill.number.toLocaleString.js
@@ -169,7 +169,7 @@
 		"hrk": "kn",
 		"cup": "₱",
 		"czk": "Kč",
-		"dkk": "kr",
+		"dkk": "kr.",
 		"dop": "RD$",
 		"xcd": "$",
 		"egp": "£",


### PR DESCRIPTION
Correct the currency denominator for Danish Crowns from `kr` to `kr.`. This is how the built-in `toLocaleString` behaves on iOS, and how the currency is denominated officially: Reference from Dansk Sprognævn: <https://dsn.dk/?retskriv=kr.+fork.>.